### PR TITLE
fix: bot info does not pop up if tag is empty

### DIFF
--- a/src/components/BotInfoPopup.vue
+++ b/src/components/BotInfoPopup.vue
@@ -126,7 +126,7 @@ class BotInfoPopup extends Vue {
       {
         title: this.$t("bot.detail.tags"),
         value: this.$createElement("span", {}, [
-          bT(this.bot, "tags").map((x) => {
+          bT(this.bot, "tags")?.map((x) => {
             return $tag(this, x);
           }),
         ]),


### PR DESCRIPTION
As title.